### PR TITLE
2023.01.31 클러스터 도메인 변경

### DIFF
--- a/en/console-user-guide.md
+++ b/en/console-user-guide.md
@@ -269,7 +269,7 @@ SELECT * FROM corona_facility_us
 
 * Setting Parameter
     * Access URL (Required) 
-        * Access URL provided on the Settings screen (ex. [https://x-x-x-x-x.cluster-dataquery.cloud.toast.com](https://x-x-x-x-x.cluster-dataquery.cloud.toast.com))
+        * Access URL provided on the Settings screen (ex. [https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com](https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com))
     * ID (Required)
         * ID provided on credentials screen
     * Password (Required)
@@ -297,7 +297,7 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
 
 * Setting parameters
     * host (Required)
-        * In the connection URL provided in the setting screen, enter the rest except for `https://` (ex . x-x-x-x-x.cluster-dataquery.cloud.toast.com).
+        * In the connection URL provided in the setting screen, enter the rest except for `https://` (ex . x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com).
     * port (Required)
         * Enter 443.
     * catalog
@@ -305,5 +305,5 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
     * schema
         * Schema name to connect
 * Example of connection information
-    * jdbc:trino://test-dataquery-domain-12345abcd.cluster-dataquery.cloud.toast.com:443/catalog/schema
+    * jdbc:trino://test-dataquery-domain-12345abcd.kr1-cluster-dataquery.nhncloudservice.com:443/catalog/schema
 * For more details, see [Trino JDBC Guide](https://trino.io/docs/398/client/jdbc.html).

--- a/ja/console-user-guide.md
+++ b/ja/console-user-guide.md
@@ -269,7 +269,7 @@ SELECT * FROM corona_facility_us
 
 * 設定パラメータ
     * 接続URL(必須)
-        * 設定画面で提供された接続URL (ex. [https://x-x-x-x-x.cluster-dataquery.cloud.toast.com](https://x-x-x-x-x.cluster-dataquery.cloud.toast.com))
+        * 設定画面で提供された接続URL (ex. [https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com](https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com))
     * ID(必須)
         * 認証情報画面で提供されたID
     * パスワード(必須)
@@ -297,7 +297,7 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
 
 * 設定パラメータ
     * host(必須)
-        * 設定画面で提供された接続URLで`https://`以外の部分を入力します(ex . x-x-x-x-x.cluster-dataquery.cloud.toast.com)。
+        * 設定画面で提供された接続URLで`https://`以外の部分を入力します(ex . x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com)。
     * port(必須)
         * 443を入力します。
     * catalog
@@ -305,5 +305,5 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
     * schema
         * 接続したいスキーマ名
 * 接続情報例
-    * jdbc:trino://test-dataquery-domain-12345abcd.cluster-dataquery.cloud.toast.com:443/catalog/schema
+    * jdbc:trino://test-dataquery-domain-12345abcd.kr1-cluster-dataquery.nhncloudservice.com:443/catalog/schema
 * 詳細は[Trino JDBCガイドページ](https://trino.io/docs/398/client/jdbc.html)をご覧ください。

--- a/ko/console-user-guide.md
+++ b/ko/console-user-guide.md
@@ -269,7 +269,7 @@ SELECT * FROM corona_facility_us
 
 * 설정 파라미터
     * 접속 URL(필수)
-        * 설정 화면에서 제공 받은 접속 URL (ex. [https://x-x-x-x-x.cluster-dataquery.cloud.toast.com](https://x-x-x-x-x.cluster-dataquery.cloud.toast.com))
+        * 설정 화면에서 제공 받은 접속 URL (ex. [https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com](https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com))
     * 아이디(필수)
         * 인증 정보 화면에서 제공 받은 아이디
     * 비밀번호(필수)
@@ -297,7 +297,7 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
 
 * 설정 파라미터
     * host(필수)
-        * 설정 화면에서 제공 받은 접속 URL에서 `https://`를 제외한 나머지를 입력합니다(ex . x-x-x-x-x.cluster-dataquery.cloud.toast.com).
+        * 설정 화면에서 제공 받은 접속 URL에서 `https://`를 제외한 나머지를 입력합니다(ex . x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com).
     * port(필수)
         * 443을 입력합니다.
     * catalog
@@ -305,5 +305,5 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
     * schema
         * 연결을 원하는 스키마 이름
 * 접속 정보 예시
-    * jdbc:trino://test-dataquery-domain-12345abcd.cluster-dataquery.cloud.toast.com:443/catalog/schema
+    * jdbc:trino://test-dataquery-domain-12345abcd.kr1-cluster-dataquery.nhncloudservice.com:443/catalog/schema
 * 더 자세한 정보는 [Trino JDBC 가이드 페이지](https://trino.io/docs/398/client/jdbc.html)를 참고하십시오.

--- a/zh/console-user-guide.md
+++ b/zh/console-user-guide.md
@@ -267,7 +267,7 @@ SELECT * FROM corona_facility_us
 
 * Setting Parameter
     * Access URL (Required) 
-        * Access URL provided on the Settings screen (ex. [https://x-x-x-x-x.cluster-dataquery.cloud.toast.com](https://x-x-x-x-x.cluster-dataquery.cloud.toast.com))
+        * Access URL provided on the Settings screen (ex. [https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com](https://x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com))
     * ID (Required)
         * ID provided on credentials screen
     * Password (Required)
@@ -295,7 +295,7 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
 
 * Setting parameters
     * host (Required)
-        * In the connection URL provided in the setting screen, enter the rest except for `https://` (ex . x-x-x-x-x.cluster-dataquery.cloud.toast.com).
+        * In the connection URL provided in the setting screen, enter the rest except for `https://` (ex . x-x-x-x-x.kr1-cluster-dataquery.nhncloudservice.com).
     * port (Required)
         * Enter 443.
     * catalog
@@ -303,5 +303,5 @@ jdbc:trino://${host}:${port}/${catalog}/${schema}
     * schema
         * Schema name to connect
 * Example of connection information
-    * jdbc:trino://test-dataquery-domain-12345abcd.cluster-dataquery.cloud.toast.com:443/catalog/schema
+    * jdbc:trino://test-dataquery-domain-12345abcd.kr1-cluster-dataquery.nhncloudservice.com:443/catalog/schema
 * For more details, see [Trino JDBC Guide](https://trino.io/docs/398/client/jdbc.html).


### PR DESCRIPTION
## 작업 내용
* 가이드 본문의 클러스터 도메인을 변경된 클러스터 도메인으로 변경하였습니다.
  * x.x.x.x.cluster-dataquery.cloud.toast.com -> x.x.x.x.kr1-cluster-dataquery.nhncloudservice.com